### PR TITLE
Configure.ac bug fixed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([rest-client-c], [1.0.2], [jason_d0t_cwik@emc_d0t_com])
-m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_CONFIG_AUX_DIR([build-aux])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 LT_INIT


### PR DESCRIPTION
configure.ac has a bug, i run the configure script in windows ubuntu bash and throw an error i solved moving AC_CONFIG_AUX_DIR to line 2 instead of line 3.